### PR TITLE
Minor fixes to zsh installation

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -70,7 +70,7 @@ ENABLE_CORRECTION="true"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git zsh-autosuggestions sudo web-search copydir copyfile copybuffer dirhistory history jsontools z bgnotify vscode command-not-found)
+plugins=(git zsh-autosuggestions sudo web-search copypath copyfile copybuffer dirhistory history jsontools z bgnotify vscode command-not-found)
 
 source $ZSH/oh-my-zsh.sh
 
@@ -103,7 +103,7 @@ export ARCHFLAGS="-arch x86_64"
 # eval `dircolors ~/.dir_colors/dircolors`
 prompt_context() {} 
 
-source /home/chekhovoiv/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source /home/${USER}/.zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 
 #disable auto correct
 unsetopt correct_all

--- a/setup
+++ b/setup
@@ -5,7 +5,6 @@ sudo ./apt-packages.sh
 ./terminal.sh
 ./vim.sh
 ./tmux.sh
-./misc.sh
 
 
 if [ $# -eq 1 ]

--- a/terminal.sh
+++ b/terminal.sh
@@ -1,11 +1,12 @@
 printf "Setting up Terminator...\n"
-cp configs/terminator-config /home/$USER/.config/terminator/config
-chsh -s $(which zsh)
+mkdir -p /home/$USER/.config/terminator/
+cp configs/terminator_config /home/$USER/.config/terminator/config
+sudo chsh -s $(which zsh)
 printf "Switched the shell to zsh, please reboot the system after the program finishes!\n"
 
 
 printf "Installing Oh My ZSH (awesome zsh)\n"
 cp configs/.zshrc /home/$USER/.zshrc
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
-git clone git://github.com/sigurdga/gnome-terminal-colors-solarized.git ~/.solarized
-git clone https://github.com/zsh-users/zsh-syntax-highlighting.git
+git clone https://github.com/aruhier/gnome-terminal-colors-solarized.git  ~/.solarized
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.zsh-syntax-highlighting


### PR DESCRIPTION
* minor config paths adjustments
* creation of the `/home/$USER/.config/terminator/` folder
* cloning from https://github.com/aruhier/gnome-terminal-colors-solarized.git instead of https://github.com/sigurdga/gnome-terminal-colors-solarized.git, as the library seems to have changed owners
* removed the invocation of the deprecated `./misc.sh` from `setup`
* updated `copydir` to `copypath` as per the deprecation warning